### PR TITLE
`README`: fix hyperlinks to `examples` and `parrot_v_thrust` pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,8 +95,8 @@ See detailed comparisons in our [documentation](https://nvlabs.github.io/parrot/
 ## 📚 Documentation
 
 - **[Full Documentation](https://nvlabs.github.io/parrot/)** - Complete API reference and examples
-- **[Examples](docs/examples.rst)** - Standalone Parrot examples
-- **[vs Thrust](docs/parrot_v_thrust.rst)** - Side-by-side comparisons with Thrust
+- **[Examples](https://nvlabs.github.io/parrot/examples.html)** - Standalone Parrot examples
+- **[vs Thrust](https://nvlabs.github.io/parrot/parrot_v_thrust.html)** - Side-by-side comparisons with Thrust
 
 
 ## 🧪 Examples


### PR DESCRIPTION
Currently broken, since you have `docs/examples.rst` and `docs/parrot_v_thrust.rst` in your `.gitignore`.