### PR TITLE
:sparkles: Add `nrows` & `ncols`

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ int main() {
 using namespace parrot::literals;
 
 auto softmax(auto matrix) {
-    auto cols = matrix.shape()[1];
+    auto cols = matrix.ncols();
     auto z    = matrix - matrix.maxr(2_ic).replicate(cols);
     auto num  = z.exp();
     auto den  = num.sum(2_ic);

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -27,7 +27,7 @@ Quick Start
        auto matrix = parrot::range(10000).as<float>().reshape({100, 100});
 
        // Calculate the row-wise softmax of a matrix
-       auto cols = matrix.shape()[1];
+       auto cols = matrix.ncols();
        auto z    = matrix - matrix.maxr<2>().replicate(cols);
        auto num  = z.exp();
        auto den  = num.sum<2>();

--- a/examples/machine_learning/softmax.cu
+++ b/examples/machine_learning/softmax.cu
@@ -3,7 +3,7 @@
 using namespace parrot::literals;
 
 auto softmax(auto matrix) {
-    auto cols = matrix.shape()[1];
+    auto cols = matrix.ncols();
     auto z    = matrix - matrix.maxr(2_ic).replicate(cols);
     auto num  = z.exp();
     auto den  = num.sum(2_ic);

--- a/parrot.hpp
+++ b/parrot.hpp
@@ -892,6 +892,32 @@ class fusion_array {
      */
     [[nodiscard]] auto rank() const -> int { return _shape.size(); }
 
+    /**
+     * @brief Get the number of rows in a 2D array
+     * @return The number of rows (first dimension)
+     * @throws std::runtime_error if the array rank is not 2
+     */
+    [[nodiscard]] auto nrows() const -> int {
+        if (rank() != 2) {
+            throw std::runtime_error(
+              "nrows() can only be called on rank-2 arrays");
+        }
+        return _shape[0];
+    }
+
+    /**
+     * @brief Get the number of columns in a 2D array
+     * @return The number of columns (second dimension)
+     * @throws std::runtime_error if the array rank is not 2
+     */
+    [[nodiscard]] auto ncols() const -> int {
+        if (rank() != 2) {
+            throw std::runtime_error(
+              "ncols() can only be called on rank-2 arrays");
+        }
+        return _shape[1];
+    }
+
     // Map operation with another fusion_array
     template <typename OtherIterator,
               typename OtherMaskIterator,

--- a/tests/test_array_operations.cu
+++ b/tests/test_array_operations.cu
@@ -320,8 +320,8 @@ TEST_CASE("ParrotTest - OuterBasicTest") {
     // [2*4, 2*5]  = [8, 10]
     // [3*4, 3*5]  = [12, 15]
     CHECK_EQ(result.size(), 4);
-    CHECK_EQ(result.shape()[0], 2);
-    CHECK_EQ(result.shape()[1], 2);
+    CHECK_EQ(result.nrows(), 2);
+    CHECK_EQ(result.ncols(), 2);
 
     auto result_host = result.to_host();
     CHECK_EQ(result_host[0], 8);   // 2*4

--- a/tests/test_fun.cu
+++ b/tests/test_fun.cu
@@ -228,7 +228,7 @@ using namespace parrot::literals;
 
 auto team_champion(auto arr) {
     auto sums = arr.sum(2_ic);
-    return parrot::range(arr.shape()[0])
+    return parrot::range(arr.nrows())
       .minus(1)
       .keep(sums.maxr() == sums)
       .front();

--- a/tests/test_integration.cu
+++ b/tests/test_integration.cu
@@ -404,7 +404,7 @@ TEST_CASE("ParrotTest - CompositeStorage_ReductionDivision") {
 
 auto softmax(auto matrix) {
     using namespace parrot::literals;
-    auto cols = matrix.shape()[1];
+    auto cols = matrix.ncols();
     auto z    = matrix - matrix.maxr(2_ic).replicate(cols);
     auto num  = z.exp();
     auto den  = num.sum(2_ic);

--- a/tests/test_multidimensional.cu
+++ b/tests/test_multidimensional.cu
@@ -101,8 +101,8 @@ TEST_CASE("ParrotTest - ReshapeTest") {
     // Check that the shape is correct
     auto shape = reshaped.shape();
     REQUIRE_EQ(shape.size(), 2);
-    CHECK_EQ(shape[0], 2);
-    CHECK_EQ(shape[1], 3);
+    CHECK_EQ(reshaped.nrows(), 2);
+    CHECK_EQ(reshaped.ncols(), 3);
 
     // Verify the total size remains the same
     CHECK_EQ(reshaped.size(), 6);
@@ -127,8 +127,8 @@ TEST_CASE("ParrotTest - ReshapeTruncateTest") {
     // Check that the shape is correct
     auto shape = reshaped.shape();
     REQUIRE_EQ(shape.size(), 2);
-    CHECK_EQ(shape[0], 2);
-    CHECK_EQ(shape[1], 2);
+    CHECK_EQ(reshaped.nrows(), 2);
+    CHECK_EQ(reshaped.ncols(), 2);
 
     // Verify the total size is updated
     CHECK_EQ(reshaped.size(), 4);
@@ -199,8 +199,8 @@ TEST_CASE("ParrotTest - CycleEqualSizeTest") {
     // Check that the shape is correct
     auto shape = cycled.shape();
     REQUIRE_EQ(shape.size(), 2);
-    CHECK_EQ(shape[0], 2);
-    CHECK_EQ(shape[1], 3);
+    CHECK_EQ(cycled.nrows(), 2);
+    CHECK_EQ(cycled.ncols(), 3);
 
     // Verify the total size remains the same
     CHECK_EQ(cycled.size(), 6);
@@ -230,8 +230,8 @@ TEST_CASE("ParrotTest - CycleSmallerSizeTest") {
     // Check that the shape is correct
     auto shape = cycled.shape();
     REQUIRE_EQ(shape.size(), 2);
-    CHECK_EQ(shape[0], 2);
-    CHECK_EQ(shape[1], 2);
+    CHECK_EQ(cycled.nrows(), 2);
+    CHECK_EQ(cycled.ncols(), 2);
 
     // Verify the total size is updated
     CHECK_EQ(cycled.size(), 4);
@@ -351,8 +351,8 @@ TEST_CASE("ParrotTest - MatrixTest") {
     // Check that the shape is correct (2D)
     auto shape = mat.shape();
     REQUIRE_EQ(shape.size(), 2);
-    CHECK_EQ(shape[0], 3);
-    CHECK_EQ(shape[1], 4);
+    CHECK_EQ(mat.nrows(), 3);
+    CHECK_EQ(mat.ncols(), 4);
 
     // Check content - all elements should be 7
     auto host_vals = mat.to_host();
@@ -385,8 +385,8 @@ TEST_CASE("ParrotTest - NestedMatrixTest") {
     CHECK_EQ(mat.size(), 6);
     auto shape = mat.shape();
     REQUIRE_EQ(shape.size(), 2);
-    CHECK_EQ(shape[0], 2);  // rows
-    CHECK_EQ(shape[1], 3);  // cols
+    CHECK_EQ(mat.nrows(), 2);  // rows
+    CHECK_EQ(mat.ncols(), 3);  // cols
 
     // Check content (row-major order)
     auto expected = parrot::array({1, 2, 3, 4, 5, 6});
@@ -408,8 +408,8 @@ TEST_CASE("ParrotTest - NestedMatrixDoubleTest") {
     CHECK_EQ(mat.size(), 6);
     auto shape = mat.shape();
     REQUIRE_EQ(shape.size(), 2);
-    CHECK_EQ(shape[0], 3);  // rows
-    CHECK_EQ(shape[1], 2);  // cols
+    CHECK_EQ(mat.nrows(), 3);  // rows
+    CHECK_EQ(mat.ncols(), 2);  // cols
 
     // Check content
     auto expected = parrot::array({1.5, 2.5, 3.5, 4.5, 5.5, 6.5});
@@ -464,8 +464,8 @@ TEST_CASE("ParrotTest - Transpose2x3Test") {
     // Check shape
     auto shape = transposed.shape();
     REQUIRE_EQ(shape.size(), 2);
-    CHECK_EQ(shape[0], 3);
-    CHECK_EQ(shape[1], 2);
+    CHECK_EQ(transposed.nrows(), 3);
+    CHECK_EQ(transposed.ncols(), 2);
     CHECK_EQ(transposed.size(), 6);
 
     // Check content
@@ -526,8 +526,8 @@ TEST_CASE("ParrotTest - TransposeSingleColumnTest") {
     // Check shape
     auto shape = transposed.shape();
     REQUIRE_EQ(shape.size(), 2);
-    CHECK_EQ(shape[0], 1);
-    CHECK_EQ(shape[1], 4);
+    CHECK_EQ(transposed.nrows(), 1);
+    CHECK_EQ(transposed.ncols(), 4);
     CHECK_EQ(transposed.size(), 4);
 
     // Check content


### PR DESCRIPTION
Closes https://github.com/NVlabs/parrot/issues/32

R calls these `nrow` / `ncol`
GNU Octave calls them `rows` / `columns`

Others just have `shape` or `size` functions with parameters or indexing into them.