### PR TITLE
Add -Wall and -Werror compiler flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,6 +166,10 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+# Add compiler flags for warnings and errors
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Werror")
+set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xcompiler=-Wall,-Werror")
+
 # Add compiler timing flags
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ftime-report")
 set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --time")

--- a/scripts/run-clang-tidy.sh
+++ b/scripts/run-clang-tidy.sh
@@ -308,6 +308,10 @@ run_clang_tidy() {
         EXTRA_ARGS_STRING="$EXTRA_ARGS_STRING -extra-arg=$include_path"
     done
     
+    # Add warning flags
+    EXTRA_ARGS_STRING="$EXTRA_ARGS_STRING -extra-arg=-Wall"
+    EXTRA_ARGS_STRING="$EXTRA_ARGS_STRING -extra-arg=-Werror"
+    
     # Add CUDA-specific flags to avoid false positive errors
     EXTRA_ARGS_STRING="$EXTRA_ARGS_STRING -extra-arg=--no-cuda-version-check"
     EXTRA_ARGS_STRING="$EXTRA_ARGS_STRING -extra-arg=-Xclang"


### PR DESCRIPTION
Closes https://github.com/NVlabs/parrot/issues/55
- Add -Wall and -Werror to CMakeLists.txt for both C++ and CUDA compilation
- Add -Wall and -Werror to clang-tidy script for static analysis
- Ensures all warnings are enabled and treated as errors
- All tests pass with no warnings