### PR TITLE
chore: docs cleanup, typos

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -8,7 +8,9 @@ This document describes how to build, test, and generate documentation for the p
 - C++ compiler with C++20 support
 - NVIDIA CUDA Toolkit 13.0 or later
 - NVIDIA GPU with compute capability 7.0 or higher
-- Python 3 with pip (for documentation, optional)
+- Optional, for documentation
+  - Python 3 with pip (or [uv](https://docs.astral.sh/uv/))
+  - [Doxygen](https://www.doxygen.nl/)
 
 <details>
 <summary><strong>CUDA Installation</strong> (Click to expand if you need to install CUDA)</summary>
@@ -154,7 +156,7 @@ The project uses Doxygen and optionally Sphinx for documentation.
 
 Install required Python packages (optional, for Sphinx):
 ```bash
-pip install sphinx sphinx-rtd-theme breathe
+pip install -r requirements.txt
 ```
 
 ## Generate Documentation

--- a/README.md
+++ b/README.md
@@ -16,12 +16,12 @@
         <img src="https://github.com/NVLabs/parrot/actions/workflows/unit-tests.yml/badge.svg" /></a>
 </p>
 
-**Parrot** is an array fusion GPU library built on NVIDIA's [CCCL libaries](https://nvidia.github.io/cccl/unstable/cpp.html#cccl-cpp-libraries) (Thrust/CUB). It provides efficient GPU-accelerated operations with lazy evaluation semantics, allowing for chaining of operations without unnecessary intermediate materializations.
+**Parrot** is an array fusion GPU library built on NVIDIA's [CCCL libraries](https://nvidia.github.io/cccl/unstable/cpp.html#cccl-cpp-libraries) (Thrust/CUB). It provides efficient GPU-accelerated operations with lazy evaluation semantics, allowing for chaining of operations without unnecessary intermediate materializations.
 
 ## ✨ Features
 
 - **Implicit Fusion** - Implicit fusion of operations
-- **GPU Acceleration** - Built on NVIDIA's [CCCL libaries](https://nvidia.github.io/cccl/unstable/cpp.html#cccl-cpp-libraries) (Thrust/CUB) for high performance
+- **GPU Acceleration** - Built on NVIDIA's [CCCL libraries](https://nvidia.github.io/cccl/unstable/cpp.html#cccl-cpp-libraries) (Thrust/CUB) for high performance
 - **Chainable API** - Clean, expressive syntax for complex operations
 - **Header-Only** - Simple integration with `#include "parrot.hpp"`
 
@@ -113,7 +113,9 @@ See detailed comparisons in our [documentation](https://nvlabs.github.io/parrot/
 The [`examples/`](examples/) directory contains:
 
 - **`getting_started/`** - Simple examples to get started
-- **`thrust/`** - Parrot implementations of Thrust examples  
+- **`machine_learning/`** - Machine learning examples
+- **`thrust/`** - Parrot implementations of Thrust examples
+- **`real_world/`** - Parrot versions of examples from open source projects
 
 
 ## 🛠️ Development
@@ -160,11 +162,12 @@ parrot/
 ├── thrustx.hpp             # Extended Thrust utilities
 ├── examples/               # Example code
 │   ├── getting_started/    # Simple getting-started examples
+│   ├── machine_learning/   # Softmax, more to come
 │   ├── thrust/             # Parrot versions of Thrust examples
-│   ├── real_world/         # Parrot versions of examples from open source projects
-├── tests/                  # Unit tests
+│   └── real_world/         # Parrot versions of examples from open source projects
 ├── docs/                   # Documentation source
-├── scripts/                # Development scripts
+├── tests/                  # Unit tests
+└── scripts/                # Development scripts
 ```
 
 ## 🤝 Contributing

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,7 +11,7 @@ Features
 ~~~~~~~~
 
 * Implicit fusion¹ of array operations
-* GPU acceleration using NVIDIA's `CCCL libaries <https://nvidia.github.io/cccl/unstable/cpp.html#cccl-cpp-libraries>`_ (Thrust/CUB)
+* GPU acceleration using NVIDIA's `CCCL libraries <https://nvidia.github.io/cccl/unstable/cpp.html#cccl-cpp-libraries>`_ (Thrust/CUB)
 * Chainable operations with a clean API
 * Header-only with ``#include "parrot.hpp"``
 


### PR DESCRIPTION
# Summary

Fixing a couple of small issues with the docs.
- Typos: `libaries` -> `libraries`
- Out of date (incomplete) pip reqs list
- Added missing`machine_learning/` folder to examples list
- Small formatting issues with file tree
- Restructured the bit talking about pre-reqs to include Doxygen for the docs

`P.S.`: Happy to convert the `logo.png` to a favicon as well, as the docs site is currently missing one.

# Testing

<details>
  <summary>Tests passing</summary>
  
  `ctest` passes
  
  ```
  parrot/build on  tytr/docs-fixes via △ v4.3.3 
❯ ctest
Test project /home/ty/gpu/parrot/build
      Start  1: ParrotTests
 1/12 Test  #1: ParrotTests ......................   Passed    0.45 sec
      Start  2: BasicOperationsTests
 2/12 Test  #2: BasicOperationsTests .............   Passed    0.22 sec
      Start  3: SortingTests
 3/12 Test  #3: SortingTests .....................   Passed    0.18 sec
      Start  4: MathOperationsTests
 4/12 Test  #4: MathOperationsTests ..............   Passed    0.18 sec
      Start  5: ReductionsTests
 5/12 Test  #5: ReductionsTests ..................   Passed    0.15 sec
      Start  6: ScansTests
 6/12 Test  #6: ScansTests .......................   Passed    0.15 sec
      Start  7: ArrayOperationsTests
 7/12 Test  #7: ArrayOperationsTests .............   Passed    0.15 sec
      Start  8: AdvancedOperationsTests
 8/12 Test  #8: AdvancedOperationsTests ..........   Passed    0.15 sec
      Start  9: MultidimensionalTests
 9/12 Test  #9: MultidimensionalTests ............   Passed    0.14 sec
      Start 10: IntegrationTests
10/12 Test #10: IntegrationTests .................   Passed    0.15 sec
      Start 11: Top10Tests
11/12 Test #11: Top10Tests .......................   Passed    0.15 sec
      Start 12: FunTests
12/12 Test #12: FunTests .........................   Passed    0.15 sec

100% tests passed, 0 tests failed out of 12

Total Test time (real) =   2.22 sec
  ```
  
</details>

<details>
  <summary>Docs Building</summary>
  
  `./build_docs.sh` passes
  
  ```
...
pickling environment... done
checking consistency... /home/ty/gpu/parrot/docs/api/library_root.rst: WARNING: document isn't included in any toctree
done
preparing documents... done
copying assets... copying static files... done
copying extra files... done
done
writing output... [100%] parrot_v_thrust
generating indices... genindex done
highlighting module code... 
writing additional pages... search done
dumping search index in English (code: en)... done
dumping object inventory... done
build succeeded, 13 warnings.

The HTML pages are in build/html.
Documentation built successfully in docs/_build/html/
Documentation build complete!
  ```
  
</details>

<img width="719" height="220" alt="image" src="https://github.com/user-attachments/assets/010d13c1-c9de-4443-9293-7b96b9bd3309" />
