### PR TITLE
Boolean array specialization for sort()

### DIFF
--- a/parrot.hpp
+++ b/parrot.hpp
@@ -1408,8 +1408,21 @@ class fusion_array {
         auto sorted_data = std::make_shared<thrust::device_vector<value_type>>(
           n, thrust::default_init);
 
-        thrust::copy(_begin, _end, sorted_data->begin());
-        thrust::sort(sorted_data->begin(), sorted_data->end());
+        if constexpr (std::is_same_v<value_type, bool>) {
+            // Sorting a bool array is a partition: count the trues and fill
+            // [falses..trues] directly.
+            int const num_true  = thrust::count(_begin, _end, true);
+            int const num_false = n - num_true;
+            thrust::fill(sorted_data->begin(),
+                         sorted_data->begin() + num_false,
+                         false);
+            thrust::fill(sorted_data->begin() + num_false,
+                         sorted_data->end(),
+                         true);
+        } else {
+            thrust::copy(_begin, _end, sorted_data->begin());
+            thrust::sort(sorted_data->begin(), sorted_data->end());
+        }
 
         // Return a new fusion_array with ownership of the sorted data
         return fusion_array<

--- a/parrot.hpp
+++ b/parrot.hpp
@@ -1413,12 +1413,10 @@ class fusion_array {
             // [falses..trues] directly.
             int const num_true  = thrust::count(_begin, _end, true);
             int const num_false = n - num_true;
-            thrust::fill(sorted_data->begin(),
-                         sorted_data->begin() + num_false,
-                         false);
-            thrust::fill(sorted_data->begin() + num_false,
-                         sorted_data->end(),
-                         true);
+            thrust::fill(
+              sorted_data->begin(), sorted_data->begin() + num_false, false);
+            thrust::fill(
+              sorted_data->begin() + num_false, sorted_data->end(), true);
         } else {
             thrust::copy(_begin, _end, sorted_data->begin());
             thrust::sort(sorted_data->begin(), sorted_data->end());

--- a/tests/test_sorting.cu
+++ b/tests/test_sorting.cu
@@ -17,6 +17,8 @@
 
 #include "parrot.hpp"
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include <algorithm>
+#include <vector>
 #include "test_common.hpp"
 
 // Define a key function that extracts the parity (0 for even, 1 for odd)
@@ -55,7 +57,7 @@ TEST_CASE("ParrotTest - SortByKeyTest") {
     int count_even    = 0;
     int count_odd     = 0;
     auto sorted_host  = sorted
-                         .to_host();  // Assuming to_host() returns std::vector
+                          .to_host();  // Assuming to_host() returns std::vector
 
     REQUIRE_EQ(sorted_host.size(), arr.size());
 
@@ -75,6 +77,73 @@ TEST_CASE("ParrotTest - SortByKeyTest") {
 
     // Verify total is the same
     CHECK_EQ(arr.sum().value(), sorted.sum().value());
+}
+
+// Check that a bool array sorts to all falses then all trues, with the number
+// of trues preserved
+static void check_bool_sorted(const std::vector<bool>& input) {
+    auto arr    = parrot::array(input);
+    auto sorted = arr.sort();
+    auto host   = sorted.to_host();
+
+    REQUIRE_EQ(host.size(), input.size());
+
+    bool seen_true  = false;
+    size_t num_true = 0;
+    for (size_t i = 0; i < host.size(); ++i) {
+        if (host[i]) {
+            seen_true = true;
+            ++num_true;
+        } else {
+            CHECK_MESSAGE(!seen_true,
+                          "Found a false after a true (not sorted)");
+        }
+    }
+
+    size_t expected_true = static_cast<size_t>(
+      std::count(input.begin(), input.end(), true));
+    CHECK_EQ(num_true, expected_true);
+}
+
+// Test sort function on a bool array (count + fill specialization)
+TEST_CASE("ParrotTest - BoolSortMixed") {
+    check_bool_sorted({true, false, true, false, false, true, false});
+}
+
+// Test bool sort with all false values
+TEST_CASE("ParrotTest - BoolSortAllFalse") {
+    check_bool_sorted({false, false, false, false});
+}
+
+// Test bool sort with all true values
+TEST_CASE("ParrotTest - BoolSortAllTrue") {
+    check_bool_sorted({true, true, true, true});
+}
+
+// Test bool sort with a single element
+TEST_CASE("ParrotTest - BoolSortSingleElement") {
+    check_bool_sorted({true});
+    check_bool_sorted({false});
+}
+
+// Test bool sort with an empty array
+TEST_CASE("ParrotTest - BoolSortEmpty") {
+    auto arr    = parrot::array(std::vector<bool>{});
+    auto sorted = arr.sort();
+    CHECK_EQ(sorted.size(), 0);
+}
+
+// Test bool sort with an already-sorted array
+TEST_CASE("ParrotTest - BoolSortAlreadySorted") {
+    check_bool_sorted({false, false, true, true});
+}
+
+// Test sort on a non-bool array still uses the comparison sort
+TEST_CASE("ParrotTest - SortNonBoolUnaffected") {
+    auto arr      = parrot::array({3.5, 1.25, 2.75, 0.5});
+    auto sorted   = arr.sort();
+    auto expected = parrot::array({0.5, 1.25, 2.75, 3.5});
+    CHECK(check_match(sorted, expected));
 }
 
 // Test uniq function for removing adjacent duplicates

--- a/tests/test_sorting.cu
+++ b/tests/test_sorting.cu
@@ -57,7 +57,7 @@ TEST_CASE("ParrotTest - SortByKeyTest") {
     int count_even    = 0;
     int count_odd     = 0;
     auto sorted_host  = sorted
-                          .to_host();  // Assuming to_host() returns std::vector
+                         .to_host();  // Assuming to_host() returns std::vector
 
     REQUIRE_EQ(sorted_host.size(), arr.size());
 


### PR DESCRIPTION
## Summary

As per https://github.com/NVlabs/parrot/issues/88, this implements a compile time constexpr branch for boolean arrays to avoid sorting. Goal is saving cycles.

Measured on an RTX 3090 over 67M elements:

| Time | bool `sort()` |
|---|---|
| thrust::sort | 3.70 ms |
| count + fill | 1.68 ms |

## Changes

- **enhancement: avoid sort on bool array**

## Testing

<details>
  <summary>Running new unit tests</summary>

parrot on  tytr/bool-array-sort [!] via △ v4.3.3 via 🐍 v3.14.5 took 16s 
❯ ./parrot_tests --test-case="*Sort*,*Bool*"
[100%] Built target parrot_tests
[doctest] doctest version is "2.4.11"
[doctest] run with "--help" for options
===============================================================================
[doctest] test cases: 10 | 10 passed | 0 failed | 223 skipped
[doctest] assertions: 37 | 37 passed | 0 failed |
[doctest] Status: SUCCESS!
</details>

<details>
  <summary>Full test run</summary>

parrot/build on  tytr/bool-array-sort [!] via △ v4.3.3 
❯ ctest --output-on-failure
Test project /home/ty/gpu/parrot/build
      Start  1: ParrotTests
 1/12 Test  #1: ParrotTests ......................   Passed    0.53 sec
      Start  2: BasicOperationsTests
 2/12 Test  #2: BasicOperationsTests .............   Passed    0.27 sec
      Start  3: SortingTests
 3/12 Test  #3: SortingTests .....................   Passed    0.19 sec
      Start  4: MathOperationsTests
 4/12 Test  #4: MathOperationsTests ..............   Passed    0.17 sec
      Start  5: ReductionsTests
 5/12 Test  #5: ReductionsTests ..................   Passed    0.16 sec
      Start  6: ScansTests
 6/12 Test  #6: ScansTests .......................   Passed    0.14 sec
      Start  7: ArrayOperationsTests
 7/12 Test  #7: ArrayOperationsTests .............   Passed    0.14 sec
      Start  8: AdvancedOperationsTests
 8/12 Test  #8: AdvancedOperationsTests ..........   Passed    0.13 sec
      Start  9: MultidimensionalTests
 9/12 Test  #9: MultidimensionalTests ............   Passed    0.13 sec
      Start 10: IntegrationTests
10/12 Test #10: IntegrationTests .................   Passed    0.14 sec
      Start 11: Top10Tests
11/12 Test #11: Top10Tests .......................   Passed    0.13 sec
      Start 12: FunTests
12/12 Test #12: FunTests .........................   Passed    0.14 sec

100% tests passed, 0 tests failed out of 12

Total Test time (real) =   2.27 sec
</details>

## Notes

I kept this limited to `sort()` for now since it was the one I had clear sight of.
I'd like to test directly against `thrust::partition` and maybe a few other approaches to check for the best performance here. Might need to look at a few CodeReport videos for inspiration :smile: 