### PR TITLE
:sparkles: Upgrade cccl to 3.4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -242,7 +242,7 @@ set(FETCHCONTENT_UPDATES_DISCONNECTED ON)
 FetchContent_Declare(
   cccl
   GIT_REPOSITORY https://github.com/NVIDIA/cccl.git
-  GIT_TAG v3.3.4
+  GIT_TAG v3.4.0
   GIT_SHALLOW TRUE
   TIMEOUT 60
 )


### PR DESCRIPTION
Closes https://github.com/NVlabs/parrot/issues/101